### PR TITLE
Fixing spammy mod_h2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # ea-apache2-http2
 CentOS 7, EA4 and HTTP/2. SEE LINK FOR INFO.
 
-Default symlink protection provided by Cpanel (needs additional steps, see https://documentation.cpanel.net/display/EA4/Symlink+Race+Condition+Protection) . 
-Rack911 protection still can be enabled by editing ea-apache2 (Not tested with 2.4.25 and likely will be dropped, now that 62 has the bluehost patch implemented and available in UI).

--- a/SPECS/ea-apache24.spec
+++ b/SPECS/ea-apache24.spec
@@ -16,7 +16,7 @@ Summary: Apache HTTP Server
 Name: ea-apache24
 Version: 2.4.25
 # Doing release_prefix this way for Release allows for OBS-proof versioning, See EA-4544 for more details
-%define release_prefix 101
+%define release_prefix 102
 Release: %{release_prefix}%{?dist}.cpanel.http2
 Vendor: cPanel, Inc.
 URL: http://httpd.apache.org/

--- a/SPECS/ea-apache24.spec
+++ b/SPECS/ea-apache24.spec
@@ -65,11 +65,6 @@ Patch304: 2.2_cpanel_fileprotect_suexec_httpusergroupallow.patch
 Patch305: httpd-2.4.12-apxs-modules-dir.patch
 Patch306: httpd-2.4.25-symlink.patch
 
-#OFFICIAL SYMLINK PATCH BY WHM/CPANEL IS ENABLED BY DEFAULT.
-#IF YOU WANT TO USE THE RACK911 PATCH, COMMENT OUT PATCH 306 IN BOTH LOCATIONS AND ENABLE 401
-#Symlink Protection (Rack911) (Currently untested/not compatible with 2.4.25)
-#Patch401: harden-symlinks-2.4.patch
-
 License: ASL 2.0
 Group: System Environment/Daemons
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -1219,8 +1214,6 @@ mod_watchdog hooks.
 %patch304 -p1 -b .cpsuexec3
 %patch305 -p1 -b .cpapxs
 %patch306 -p1 -b .symlink
-
-#%patch401 -p1 -b .harden
 
 # Patch in the vendor string and the release string
 sed -i '/^#define PLATFORM/s/Unix/%{vstring}/' os/unix/os.h


### PR DESCRIPTION
Apache tar has been modified by yours truly to include the latest mod_h2 (1.9.0). This is probably a crazy, reckless thing to do, but I'm a crazy, reckless guy. 
Once Apache 2.5.26 comes out, then we're going back to an unmodified tar.gz.
If my server blows up, I'll fix it and update the git. If your server blows up due to this, contact me via my web page.